### PR TITLE
login-token useContext 활용해 전역 관리

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import TokenProvider from "./context/TokenProvider";
 import Login from "./pages/Auth/Login/Login";
 import Register from "./pages/Auth/Register/Register";
 import AddTodo from "./pages/Todo/AddTodo/AddTodo";
@@ -7,13 +8,15 @@ import MainTodo from "./pages/Todo/MainTodo/MainTodo";
 const App = () => {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<MainTodo />} />
-        <Route path="todo/:id" element={<MainTodo />} />
-        <Route path="auth/login" element={<Login />} />
-        <Route path="auth/register" element={<Register />} />
-        <Route path="todo/create" element={<AddTodo />} />
-      </Routes>
+      <TokenProvider>
+        <Routes>
+          <Route path="/" element={<MainTodo />} />
+          <Route path="todo/:id" element={<MainTodo />} />
+          <Route path="auth/login" element={<Login />} />
+          <Route path="auth/register" element={<Register />} />
+          <Route path="todo/create" element={<AddTodo />} />
+        </Routes>
+      </TokenProvider>
     </BrowserRouter>
   );
 };

--- a/client/src/context/TokenContext.ts
+++ b/client/src/context/TokenContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+const TokenContext = createContext<{
+  token: string | null;
+  saveToken: (token: string) => void;
+  clearToken: () => void;
+}>({ token: null, saveToken: () => {}, clearToken: () => {} });
+
+export default TokenContext;

--- a/client/src/context/TokenProvider.tsx
+++ b/client/src/context/TokenProvider.tsx
@@ -1,0 +1,30 @@
+import { ReactNode, useCallback } from "react";
+import { useNavigate } from "react-router";
+import TokenContext from "./TokenContext";
+
+const TokenProvider = ({ children }: { children: ReactNode }) => {
+  const navigate = useNavigate();
+  const token = localStorage.getItem("login-token");
+
+  const saveToken = useCallback(
+    (token: string) => {
+      console.log("saveToken");
+      localStorage.setItem("login-token", token);
+      navigate("/");
+    },
+    [navigate],
+  );
+
+  const clearToken = useCallback(() => {
+    localStorage.removeItem("login-token");
+    navigate("/auth/login");
+  }, [navigate]);
+
+  return (
+    <TokenContext.Provider value={{ token, saveToken, clearToken }}>
+      {children}
+    </TokenContext.Provider>
+  );
+};
+
+export default TokenProvider;


### PR DESCRIPTION
### DESC
- 기존 react-query 만으로는 로그인 토큰이 전역으로 관리되지 못해 캐싱이 무효화되지 않는 문제 발생. 
-> 로그인 후에 새로고침을 해야만 todolist 에 대한 권한 부여 받음
- useContext로 token 전역 관리 후 문제 해결