### PR TITLE
기존 로그인 react-query 로직 변경 후 token에 useContext 적용해 저장

### DIFF
--- a/client/src/hook/auth/useLogin.ts
+++ b/client/src/hook/auth/useLogin.ts
@@ -1,0 +1,11 @@
+import { useMutation } from "@tanstack/react-query";
+import authAxios from "../../queries/axios";
+import { LoginResponse, UserInfo } from "../../type/userInfo";
+
+const Login = async (loginUser: UserInfo): Promise<LoginResponse> => {
+  return authAxios.post("/users/login", loginUser).then((data) => data.data);
+};
+
+export default function useLogin() {
+  return useMutation(Login);
+}

--- a/client/src/pages/Auth/Login/Login.tsx
+++ b/client/src/pages/Auth/Login/Login.tsx
@@ -22,6 +22,9 @@ import {
 import EMAIL_VALIDATION from "../../../utils/EMAIL_VALIDATION";
 import TOKEN from "./../../../utils/TOKEN";
 import { useLoginMutation } from "../../../queries/auth";
+import TokenContext from "../../../context/TokenContext";
+import { useContext } from "react";
+import useLogin from "../../../hook/auth/useLogin";
 
 const Login = () => {
   const {
@@ -31,17 +34,27 @@ const Login = () => {
   } = useForm<UserInfo>();
 
   const navigate = useNavigate();
-  const loginMutation = useLoginMutation();
-
-  if (TOKEN) {
-    navigate("/");
-  }
+  // const loginMutation = useLoginMutation();
+  const { saveToken } = useContext(TokenContext);
+  const { mutate: login } = useLogin();
 
   const onSubmitHandler: SubmitHandler<UserInfo> = async (data) => {
     const email = data.email;
     const password = data.password;
     const loginData = { email, password };
-    loginMutation.mutate(loginData);
+    // loginMutation.mutate(loginData);
+    login(loginData, {
+      onSuccess: (data) => {
+        if (data.token) {
+          console.log(data.token);
+          saveToken(data.token);
+          navigate("/");
+          return;
+        }
+        alert("로그인에 실패했습니다. 로그인 정보를 다시 확인해주세요");
+      },
+    });
+
     // try {
     //   const res = await axios.post(`${DB_DOMAIN_URL}/users/login`, loginData);
     //   if (res.status === 200) {

--- a/client/src/type/userInfo.ts
+++ b/client/src/type/userInfo.ts
@@ -8,3 +8,11 @@ export interface UserInfo {
 export interface AuthResType {
   token: string;
 }
+export interface LoginResponse {
+  message: string;
+  token: string;
+}
+export interface SignupResponse {
+  message: string;
+  token: string;
+}


### PR DESCRIPTION
### DESC
-  useLoginMutation hook 내에 문법적으로 useContext를 사용불가
- 따라서 token을 저장하는 부분에 있어서 onSuccess내부에서 saveToken hook을 활용할 수 있도록 기존 함수 로직 수정