### PR TITLE
기존 todoList 조회 react-query 로직 변경

### DIFF
--- a/client/src/hook/todo/useGetAllTodo.ts
+++ b/client/src/hook/todo/useGetAllTodo.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import authAxios from "../../queries/axios";
+import { TODO } from "../../utils/queryKeys";
+import { TodoInfo } from "./../../type/todoInfo";
+
+const getTodos = async (token: string): Promise<TodoInfo[]> => {
+  return authAxios
+    .get("/todos", {
+      headers: {
+        Authorization: token,
+      },
+    })
+    .then((data) => data.data.data);
+};
+
+export default function useGetAllTodo(token: string) {
+  return useQuery<TodoInfo[], Error>([TODO], () => getTodos(token));
+}

--- a/client/src/pages/Todo/MainTodo/MainTodo.tsx
+++ b/client/src/pages/Todo/MainTodo/MainTodo.tsx
@@ -1,9 +1,11 @@
+import { useContext } from "react";
 import { BsFillPlusCircleFill, BsPersonPlusFill } from "react-icons/bs";
 import { BiLogInCircle, BiLogOutCircle } from "react-icons/bi";
 import { useNavigate } from "react-router-dom";
 import DetailTodo from "./components/DetailTodo";
 import ListTodo from "./components/ListTodo";
 import TOKEN from "./../../../utils/TOKEN";
+import TokenContext from "../../../context/TokenContext";
 import {
   Container,
   MainTodoContainer,
@@ -20,10 +22,12 @@ import {
 } from "./MainTodoStyle";
 
 const MainTodo = () => {
+  const { token } = useContext(TokenContext);
+  const { clearToken } = useContext(TokenContext);
   const navigate = useNavigate();
 
   const addHandler = () => {
-    if (!TOKEN) {
+    if (!token) {
       alert("로그인을 해주시기 바랍니다.");
       return;
     }
@@ -37,8 +41,9 @@ const MainTodo = () => {
     navigate("/auth/login");
   };
   const LogoutHandler = () => {
-    localStorage.removeItem("login-token");
-    window.location.reload();
+    clearToken();
+    // localStorage.removeItem("login-token");
+    // window.location.reload();
     navigate("/");
   };
 
@@ -48,7 +53,7 @@ const MainTodo = () => {
         <TitleContainer>
           <MainTitleContainer>
             <p>ToDoList</p>
-            {!TOKEN && (
+            {!token && (
               <MainLoginButton
                 width={"60px"}
                 className={"loginBtn"}
@@ -57,7 +62,7 @@ const MainTodo = () => {
                 onClick={LoginHandler}
               />
             )}
-            {!TOKEN && (
+            {!token && (
               <MainRegisterButton
                 width={"60px"}
                 className={"registerBtn"}
@@ -66,7 +71,7 @@ const MainTodo = () => {
                 onClick={RegisterHandler}
               />
             )}
-            {TOKEN && (
+            {token && (
               <MainLogOutButton
                 width={"60px"}
                 className={"logoutBtn"}

--- a/client/src/pages/Todo/MainTodo/components/ListTodo.tsx
+++ b/client/src/pages/Todo/MainTodo/components/ListTodo.tsx
@@ -1,14 +1,19 @@
 import ItemTodo from "./ItemTodo";
 import { TodoInfo } from "./../../../../type/todoInfo";
 import { useGetAllTodoQuery } from "../../../../queries/todo";
-import { Key } from "react";
+import { Key, useContext } from "react";
+import TokenContext from "./../../../../context/TokenContext";
+import useGetAllTodo from "./../../../../hook/todo/useGetAllTodo";
 const ListTodo = () => {
-  const { data } = useGetAllTodoQuery();
+  // const { data } = useGetAllTodoQuery();
+
+  const { token } = useContext(TokenContext);
+  const { data } = useGetAllTodo(token!);
 
   return (
     <div>
       {data &&
-        data.data.map((task: TodoInfo, idx: Key | null | undefined) => (
+        data.map((task: TodoInfo, idx: Key | null | undefined) => (
           <ItemTodo task={task} key={idx} />
         ))}
     </div>


### PR DESCRIPTION
### DESC
- useGetAllTodo 인자로 token을 받아 todoList 조회
- 기존에는 MainTodo 페이지의 컴포넌트들이 전역으로 관리 되지 않은  TOKEN 값 유무를 조건값으로 갖고 있었기 때문에 
 로그인 후에 서버의 데이터패칭이 되지않았음
- useContext 를 활용한 token 관리로 문제 해결