### PR TITLE
사용자가 페이지를 떠날 때 정말로 떠날 것인지 묻는 확인 대화 상자를 표시

### DIFF
--- a/client/src/utils/hooks/usePreventLeave.ts
+++ b/client/src/utils/hooks/usePreventLeave.ts
@@ -1,0 +1,14 @@
+const usePreventLeave = () => {
+  const eventName = "beforeunload";
+  const handleEvent = (event: BeforeUnloadEvent) => {
+    event.preventDefault();
+    event.returnValue = "";
+  };
+
+  const enablePrevent = () => window.addEventListener(eventName, handleEvent);
+  const disablePrevent = () =>
+    window.removeEventListener(eventName, handleEvent);
+  return { enablePrevent, disablePrevent };
+};
+
+export default usePreventLeave;


### PR DESCRIPTION
### DESC

- 창이 닫히거나 새고고침을 할 경우 
- `beforeunload` 이벤트를 사용
- [beforeunload 공식문서](https://developer.mozilla.org/ko/docs/Web/API/Window/beforeunload_event)